### PR TITLE
add custom convo full history to the custom code judge decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ from guardrails_simlab_client import custom_judge, JudgeResult
 )
 def custom_judge_fn(
     user_message: str,
-    bot_response: str
+    bot_response: str,
+    messages: dict[str, str] # full conversation history
 ) -> JudgeResult:
     # Your existing logic
     # 1. Call custom LLM judge API directly

--- a/guardrails_simlab_client/decorators/custom_judge.py
+++ b/guardrails_simlab_client/decorators/custom_judge.py
@@ -83,6 +83,16 @@ def custom_judge(
                                             and test.get("response") is not None
                                         ):
                                             processor.queued_tests[test_id] = True
+                                            conversation_response = requests.get(
+                                                f"{control_plane_host}/api/experiments/{experiment['id']}/tests/{test_id}/conversations?include-adaptability-messages=true",
+                                                headers={
+                                                    "x-api-key": _get_api_key(),
+                                                },
+                                            )
+                                            if not conversation_response.ok:
+                                                message = conversation_response.json().get("message") or conversation_response.text
+                                                raise HttpError(status_code=conversation_response.status_code, message=message)
+                                            conversation = conversation_response.json()
                                             processor.processing_queue.put(
                                                 {
                                                     "experiment_id": experiment["id"],
@@ -90,6 +100,7 @@ def custom_judge(
                                                     "user_message": test["prompt"],
                                                     "bot_response": test["response"],
                                                     "risk_name": risk_name,
+                                                    "messages": conversation[0]["messages"],
                                                 }
                                             )
                                 except Exception as e:

--- a/guardrails_simlab_client/decorators/custom_judge.py
+++ b/guardrails_simlab_client/decorators/custom_judge.py
@@ -83,16 +83,16 @@ def custom_judge(
                                             and test.get("response") is not None
                                         ):
                                             processor.queued_tests[test_id] = True
-                                            conversation_response = requests.get(
-                                                f"{control_plane_host}/api/experiments/{experiment['id']}/tests/{test_id}/conversations?include-adaptability-messages=true",
+                                            conversations_response = requests.get(
+                                                f"{control_plane_host}/api/experiments/{experiment['id']}/tests/{test_id}/conversations?include-adaptability-messages=false",
                                                 headers={
                                                     "x-api-key": _get_api_key(),
                                                 },
                                             )
-                                            if not conversation_response.ok:
-                                                message = conversation_response.json().get("message") or conversation_response.text
-                                                raise HttpError(status_code=conversation_response.status_code, message=message)
-                                            conversation = conversation_response.json()
+                                            if not conversations_response.ok:
+                                                message = conversations_response.json().get("message") or conversations_response.text
+                                                raise HttpError(status_code=conversations_response.status_code, message=message)
+                                            conversations = conversations_response.json()
                                             processor.processing_queue.put(
                                                 {
                                                     "experiment_id": experiment["id"],
@@ -100,7 +100,7 @@ def custom_judge(
                                                     "user_message": test["prompt"],
                                                     "bot_response": test["response"],
                                                     "risk_name": risk_name,
-                                                    "messages": conversation[0]["messages"],
+                                                    "messages": conversations[0]["messages"],
                                                 }
                                             )
                                 except Exception as e:

--- a/guardrails_simlab_client/decorators/custom_judge.py
+++ b/guardrails_simlab_client/decorators/custom_judge.py
@@ -67,7 +67,7 @@ def custom_judge(
                                         f"=== checking for tests for experiment {experiment['id']}"
                                     )
                                     tests_response = requests.get(
-                                        f"{control_plane_host}/api/experiments/{experiment['id']}/tests?appId={_get_app_id(application_id)}&unevaluated-risk={quote_plus(risk_name)}&include-risk-evaluations=false",
+                                        f"{control_plane_host}/api/experiments/{experiment['id']}/tests?appId={_get_app_id(application_id)}&unevaluated-risk={quote_plus(risk_name)}&include-risk-evaluations=true",
                                         headers={"x-api-key": _get_api_key()},
                                     )
 

--- a/guardrails_simlab_client/processors/risk_evaluation_processor.py
+++ b/guardrails_simlab_client/processors/risk_evaluation_processor.py
@@ -70,6 +70,7 @@ class RiskEvaluationProcessor:
             user_message = test_data["user_message"]
             bot_response = test_data["bot_response"]
             risk_name = test_data["risk_name"]
+            messages = test_data.get("messages", [])
 
             LOGGER.debug(
                 f"Evaluating risk for experiment_id: {experiment_id}, test_id: {test_id}"
@@ -80,6 +81,7 @@ class RiskEvaluationProcessor:
             judge_response: JudgeResult = fn(
                 user_message,
                 bot_response,
+                messages,
             )
 
             LOGGER.debug(f"Risk evaluation result: {judge_response}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "guardrails-ai-simlab-client"
-version = "0.2.5"
+version = "0.2.6"
 authors = [
     {name = "Guardrails AI", email = "contact@guardrailsai.com"}
 ]


### PR DESCRIPTION
can test with
```
@custom_judge(
    risk_name="Long Conversations",
    enable=True,
    application_id="4a623d44-5e7d-4413-ac91-b5f6dcd3d2c5"
)
def custom_judge_fn(
    user_message: str,
    bot_response: str,
    messages: list[dict[str, str]],
) -> JudgeResult:
    print(f"Running custom_judge_fn: {user_message=}, {bot_response=}, {messages=}")
    if (messages is not None) and len(messages) > 2:
        return JudgeResult(
            justification="Long Convo Detected",
            triggered=True,
        )

    return JudgeResult(
            justification="Not a long convo",
            triggered=False,
    )
```